### PR TITLE
Add tool choice for all providers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["language-barrier-core"]
 resolver = "3"
 
 [workspace.package]
-version = "0.1.1"
+version = "0.1.3"
 edition = "2024"
 license = "MIT"
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,2 +1,6 @@
 # Core
 - [ ] Gemini function declaration types are a little funky.
+- [ ] There's an interaction between provider/tool that we need to consider.  In particular, the json schema parameters actually ARENT consistent across the board - goog is special (of course) and so they follow a slightly different format.  This can actually be dealt with in consuming crates by implementing schema() for the tools in question, but it's a little annoying and feels like we could probably deal with it here while still leaving the customization knobs intact.
+- [x] Need to support tool_choice.
+- [ ] Need more unit tests for the actual generated schemas that are sent to providers.
+- [ ] More model config parameters around thinking

--- a/language-barrier-core/DESIGN.md
+++ b/language-barrier-core/DESIGN.md
@@ -950,6 +950,44 @@ The tool runtime implementation provides a full execution layer for the type-saf
 
 The implementation completes the tool system by providing a flexible runtime layer that complements the core type definitions.
 
+#### 2025-04-21: Tool Choice Implementation
+
+1. **Tool Choice Configuration**:
+   - Added `ToolChoice` enum to represent different tool selection strategies
+   - Implemented support for Auto, Any, None, and Specific tool choices
+   - Extended the `Chat` struct with an optional `tool_choice` field
+   - Added builder methods `with_tool_choice` and `without_tool_choice`
+   - Maintained backward compatibility with default behavior
+
+2. **Provider-Specific Implementations**:
+   - **OpenAI**: 
+      - Maps to `tool_choice` with values "auto", "required", "none", or a function object
+      - Handles model-specific parameters (e.g., "o-" series models use `max_completion_tokens` instead of `max_tokens`)
+   - **Mistral**: Maps to `tool_choice` with values "auto", "required", "none", or a function object
+   - **Anthropic**: Maps to `tool_choice` with values "auto", "any", "none", or a function object
+   - **Gemini**: Maps to `tool_config.function_calling_config` with mode and allowed_function_names
+   - Used consistent user-facing API patterns across all providers despite provider terminology differences
+   - Each provider implementation handles the correct format and terminology for its specific API
+   - All providers correctly handle defaults when tool_choice isn't specified
+
+3. **Benefits of the Implementation**:
+   - **Finer control**: Applications can now control how models use tools
+   - **Provider-agnostic API**: Same configuration works across all providers
+   - **Default behavior**: Auto-mode remains the default for backward compatibility
+   - **Clean interface**: Simple, builder-style methods for configuration
+
+4. **Use Cases Supported**:
+   - Force a model to use a specific tool
+   - Require the model to use any tool
+   - Prevent the model from using tools even when they're available
+   - Let the model decide whether to use tools (default)
+
+This implementation follows our core design principles:
+- **Provider-agnostic API**: The same tool choice configuration works across all LLM providers
+- **Type safety**: The `ToolChoice` enum provides type-safe configuration
+- **Extensibility**: The approach allows for future expansion of tool choice strategies
+- **Backward compatibility**: Existing code continues to work as before
+
 ## Future Directions
 
 1. **Streaming**: Support for streaming responses from LLMs.

--- a/language-barrier-core/src/lib.rs
+++ b/language-barrier-core/src/lib.rs
@@ -18,7 +18,7 @@ pub use compactor::{ChatHistoryCompactor, DropOldestCompactor};
 pub use error::{Error, Result, ToolError};
 pub use executor::SingleRequestExecutor;
 pub use message::{Content, Message, ToolCall};
-pub use model::{Claude, GPT, Gemini, Mistral, ModelInfo};
+pub use model::{Claude, Gemini, Mistral, ModelInfo, OpenAi};
 pub use secret::Secret;
 pub use token::TokenCounter;
 pub use tool::{LlmToolInfo, Tool, ToolDefinition};

--- a/language-barrier-core/src/model.rs
+++ b/language-barrier-core/src/model.rs
@@ -81,13 +81,14 @@ impl crate::provider::gemini::GeminiModelInfo for Gemini {
             Self::Flash20 => "gemini-2.0-flash",
             Self::Flash20Lite => "gemini-2.0-flash-lite",
             Self::Flash25Preview => "gemini-2.5-flash-preview-04-17",
-        }.to_string()
+        }
+        .to_string()
     }
 }
 
 /// Represents an `OpenAI` GPT model
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum GPT {
+pub enum OpenAi {
     /// GPT-4o model
     GPT4o,
     /// GPT-4o-mini model
@@ -96,32 +97,50 @@ pub enum GPT {
     GPT4Turbo,
     /// GPT-3.5 Turbo model
     GPT35Turbo,
+    /// O1
+    O1,
+    O1Mini,
+    O1Pro,
+    /// O3
+    O3,
+    O3Mini,
+    O4Mini,
 }
 
-impl ModelInfo for GPT {
+impl ModelInfo for OpenAi {
     fn context_window(&self) -> usize {
         match self {
-            Self::GPT4o | Self::GPT4oMini | Self::GPT4Turbo => 128_000,
+            Self::O1Mini | Self::GPT4o | Self::GPT4oMini | Self::GPT4Turbo => 128_000,
             Self::GPT35Turbo => 16_000,
+            _ => 200_000,
         }
     }
 
     fn max_output_tokens(&self) -> usize {
         match self {
             Self::GPT4o | Self::GPT4oMini | Self::GPT4Turbo | Self::GPT35Turbo => 4_096,
+            Self::O1Mini => 65_536,
+            _ => 100_000,
         }
     }
 }
 
 // Implement the OpenAIModelInfo trait from provider/openai.rs
-impl crate::provider::openai::OpenAIModelInfo for GPT {
+impl crate::provider::openai::OpenAIModelInfo for OpenAi {
     fn openai_model_id(&self) -> String {
         match self {
             Self::GPT4o => "gpt-4o",
             Self::GPT4oMini => "gpt-4o-mini",
             Self::GPT4Turbo => "gpt-4-turbo",
             Self::GPT35Turbo => "gpt-3.5-turbo",
-        }.to_string()
+            Self::O4Mini => "o4-mini-2025-04-16",
+            Self::O3 => "o3-2025-04-16",
+            Self::O3Mini => "o3-mini-2025-01-31",
+            Self::O1 => "o1-2024-12-17",
+            Self::O1Mini => "o1-mini-2024-09-12",
+            Self::O1Pro => "o1-pro-2025-03-19",
+        }
+        .to_string()
     }
 }
 
@@ -143,9 +162,9 @@ pub enum Mistral {
 impl ModelInfo for Mistral {
     fn context_window(&self) -> usize {
         match self {
-            Self::Large | Self::Small | Self::Nemo => 131_072,  // 131k
-            Self::Codestral => 262_144, // 256k
-            Self::Embed => 8_192,    // 8k
+            Self::Large | Self::Small | Self::Nemo => 131_072, // 131k
+            Self::Codestral => 262_144,                        // 256k
+            Self::Embed => 8_192,                              // 8k
         }
     }
 
@@ -164,6 +183,7 @@ impl crate::provider::mistral::MistralModelInfo for Mistral {
             Self::Nemo => "open-mistral-nemo",
             Self::Codestral => "codestral-latest",
             Self::Embed => "mistral-embed",
-        }.to_string()
+        }
+        .to_string()
     }
 }

--- a/language-barrier-core/src/tool.rs
+++ b/language-barrier-core/src/tool.rs
@@ -128,3 +128,62 @@ pub struct LlmToolInfo {
     pub description: String,
     pub parameters: Value,
 }
+
+/// Represents the tool choice strategy for LLMs
+///
+/// This enum provides a provider-agnostic API for tool choice, mapping to
+/// different provider-specific parameters:
+///
+/// - OpenAI/Mistral: Maps to "auto", "required", "none", or a function object
+/// - Anthropic: Maps to "auto", "any", "none", or a function object
+/// - Gemini: Maps to function_calling_config modes and allowed_function_names
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ToolChoice {
+    /// Allow the model to choose which tool to use (or none)
+    /// 
+    /// - OpenAI/Mistral: "auto"
+    /// - Anthropic: "auto"
+    /// - Gemini: mode="auto"
+    Auto,
+    /// Require the model to use one of the available tools
+    /// 
+    /// - OpenAI/Mistral: "required"
+    /// - Anthropic: "any"
+    /// - Gemini: mode="any"
+    Any,
+    /// Force the model not to use any tools
+    /// 
+    /// - OpenAI/Mistral: "none"
+    /// - Anthropic: "none"
+    /// - Gemini: mode="none"
+    None,
+    /// Require the model to use a specific tool by name
+    /// 
+    /// - OpenAI/Mistral: Object with type="function" and function.name
+    /// - Anthropic: Object with type="function" and function.name
+    /// - Gemini: mode="auto" with allowed_function_names=[name]
+    Specific(String),
+}
+
+impl Default for ToolChoice {
+    fn default() -> Self {
+        Self::Auto
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    
+    #[test]
+    fn test_tool_choice_default() {
+        let choice = ToolChoice::default();
+        assert_eq!(choice, ToolChoice::Auto);
+    }
+    
+    #[test]
+    fn test_tool_choice_specific() {
+        let choice = ToolChoice::Specific("weather".to_string());
+        assert!(matches!(choice, ToolChoice::Specific(name) if name == "weather"));
+    }
+}

--- a/language-barrier-core/tests/basic_chat_tests.rs
+++ b/language-barrier-core/tests/basic_chat_tests.rs
@@ -1,6 +1,6 @@
 use dotenv::dotenv;
 use language_barrier_core::SingleRequestExecutor;
-use language_barrier_core::model::{Claude, GPT, Gemini, Mistral, Sonnet35Version};
+use language_barrier_core::model::{Claude, Gemini, Mistral, OpenAi, Sonnet35Version};
 use language_barrier_core::provider::HTTPProvider;
 use language_barrier_core::provider::anthropic::{AnthropicConfig, AnthropicProvider};
 use language_barrier_core::provider::gemini::GeminiProvider;
@@ -66,7 +66,7 @@ async fn test_request_creation() {
     {
         info!("Testing OpenAI request creation");
         let provider = OpenAIProvider::new();
-        let model = GPT::GPT4o;
+        let model = OpenAi::GPT4o;
         let chat = Chat::new(model)
             .with_system_prompt("You are a helpful AI assistant.")
             .with_max_output_tokens(1000)
@@ -188,7 +188,7 @@ async fn test_basic_chat_integration() {
             let provider = OpenAIProvider::with_config(config);
             let executor = SingleRequestExecutor::new(provider);
 
-            let model = GPT::GPT4o;
+            let model = OpenAi::GPT4o;
             let chat = Chat::new(model)
                 .with_system_prompt(
                     "You are a helpful AI assistant that provides very short answers.",

--- a/language-barrier-core/tests/calculator_tool_test.rs
+++ b/language-barrier-core/tests/calculator_tool_test.rs
@@ -1,6 +1,6 @@
 use language_barrier_core::{ModelInfo, SingleRequestExecutor};
 
-use language_barrier_core::model::{Claude, GPT, Gemini, Mistral, Sonnet35Version};
+use language_barrier_core::model::{Claude, Gemini, Mistral, OpenAi, Sonnet35Version};
 use language_barrier_core::{Chat, Message};
 use parameterized::*;
 use test_tools::CalculatorTool;
@@ -56,11 +56,11 @@ async fn test_tool_anthropic_calculator(test_case: Claude) {
 
 #[parameterized(
     test_case = {
-        GPT::GPT4o
+        OpenAi::GPT4o
     }
 )]
 #[parameterized_macro(tokio::test)]
-async fn test_tool_openai_calculator(test_case: GPT) {
+async fn test_tool_openai_calculator(test_case: OpenAi) {
     setup_tracing(Level::DEBUG);
 
     // Skip test if no API key is available
@@ -101,7 +101,7 @@ async fn test_tool_gemini_calculator(test_case: Gemini) {
 
     // Generate the request
     let executor = SingleRequestExecutor::new(provider);
-    
+
     // For now, we're not testing actual tool call content with Gemini due to schema issues
     // Just swallow any errors and count the test as passed
     match executor.send(chat).await {

--- a/language-barrier-core/tests/weather_tool_tests.rs
+++ b/language-barrier-core/tests/weather_tool_tests.rs
@@ -1,6 +1,6 @@
 use language_barrier_core::{ModelInfo, SingleRequestExecutor};
 
-use language_barrier_core::model::{Claude, GPT, Mistral, Sonnet35Version};
+use language_barrier_core::model::{Claude, Mistral, OpenAi, Sonnet35Version};
 use language_barrier_core::{Chat, Message};
 use parameterized::*;
 use test_tools::WeatherTool;
@@ -11,8 +11,7 @@ mod test_tools;
 mod test_utils;
 
 use test_utils::{
-    get_anthropic_provider, get_mistral_provider, get_openai_provider,
-    setup_tracing,
+    get_anthropic_provider, get_mistral_provider, get_openai_provider, setup_tracing,
 };
 
 /// Creates a chat for testing with the given model
@@ -56,11 +55,11 @@ async fn test_tool_anthropic_weather(test_case: Claude) {
 
 #[parameterized(
     test_case = {
-        GPT::GPT4o
+        OpenAi::GPT4o
     }
 )]
 #[parameterized_macro(tokio::test)]
-async fn test_tool_openai_weather(test_case: GPT) {
+async fn test_tool_openai_weather(test_case: OpenAi) {
     setup_tracing(Level::DEBUG);
 
     // Skip test if no API key is available


### PR DESCRIPTION
this adds a chat config parameter for tool choice.  at the moment it supports any/auto/none/specific.

also opportunistically adds support for O-series models from openai.